### PR TITLE
Handle opening notes without content

### DIFF
--- a/everpad/pad/editor.py
+++ b/everpad/pad/editor.py
@@ -211,7 +211,7 @@ class ContentEdit(QObject):
 
     def apply(self):
         """Apply title and content when filled"""
-        if self._title and self._content:
+        if None not in (self._title, self._content):
             self.page.mainFrame().setHtml(self._html % {
                 'title': self._title, 
                 'content': self._content,


### PR DESCRIPTION
Currently, trying to open a note created with an empty content section throws the following exception:

```
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/everpad/pad/list.py", line 74, in note_dblclicked
    self.app.indicator.open(item.note)
  File "/usr/lib/pymodules/python2.7/everpad/pad/indicator.py", line 65, in open
    editor = Editor(self.app, note)
  File "/usr/lib/pymodules/python2.7/everpad/pad/editor.py", line 601, in __init__
    self.update_title()
  File "/usr/lib/pymodules/python2.7/everpad/pad/editor.py", line 681, in update_title
    self.setWindowTitle(u'Everpad / %s' % self.note_edit.title)
  File "/usr/lib/pymodules/python2.7/everpad/pad/editor.py", line 141, in title
    self._title = soup.find(id='title').text
AttributeError: 'NoneType' object has no attribute 'text'
```

This is valid.  Content == "".   Uninitialized notes, however, have title/content == None.

This diff replaces the Truthy checks (which include content != "") with something more like an "is not None" check.
