### PR TITLE
Fix "Attache" => "Attach" typo

### DIFF
--- a/everpad/pad/editor.py
+++ b/everpad/pad/editor.py
@@ -646,7 +646,7 @@ class Editor(QMainWindow):  # TODO: kill this god shit
             self.ui.toolBar.addAction(action)
         self.ui.toolBar.addSeparator()
         self.ui.toolBar.addAction(
-            QIcon.fromTheme('add'), self.tr('Attache file'),
+            QIcon.fromTheme('add'), self.tr('Attach file'),
             self.resource_edit.add,
         )
         self.ui.toolBar.addSeparator()

--- a/i18n/ru_RU.ts
+++ b/i18n/ru_RU.ts
@@ -68,7 +68,7 @@
     </message>
     <message>
         <location filename="everpad/pad/editor.py" line="649"/>
-        <source>Attache file</source>
+        <source>Attach file</source>
         <translation>Прикрепить файл</translation>
     </message>
     <message>


### PR DESCRIPTION
"Attache" is a suitcase.  Attach is something you do with attachments
