### PR TITLE
Modalize Image Preferences Dialog

### DIFF
--- a/everpad/pad/editor.py
+++ b/everpad/pad/editor.py
@@ -364,7 +364,7 @@ class ContentEdit(QObject):
     def _show_image_dialog(self, res):
         res.w = int(self.page.active_width)
         res.h = int(self.page.active_height)
-        dialog = ImagePrefs(self.app, res)
+        dialog = ImagePrefs(self.app, res, self.parent)
         if dialog.exec_():
             w, h = dialog.get_size()
             self.page.mainFrame().evaluateJavaScript(


### PR DESCRIPTION
It's uncommon for dialog pop-ups to allow the underlying window to
remain editable.

Pass the editor window as QDialog's parent when instantiating it
