### PR TITLE
Remove extraneous whitespace in debug instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Some errors?
 ============
 For debug output you need:
 ``killall everpad everpad-provider everpad-lens``
-``everpad-provider -- verbose``
+``everpad-provider --verbose``
 And in second terminal:
 ``everpad``
 And in third:


### PR DESCRIPTION
The parameter is --verbose.  Passing '-- verbose' causes verbose to be
passed as an argument (instead of an option) and the following error to
be emitted:

```
error: unrecognized arguments: -- verbose
```
