### PR TITLE
Use window-bound QtSlots instead of console tricks in editor

### DIFF
--- a/everpad/pad/editor.html
+++ b/everpad/pad/editor.html
@@ -43,7 +43,7 @@
         var el = document.createElement('input');
         el.setAttribute('type', 'checkbox');
         el.addEventListener('change', function() {
-            console.log("change");
+            window.qpage.page_changed();
             this.setAttribute("checked", this.checked);
         }, false);
         insertEl(el);
@@ -54,7 +54,7 @@
         el.setAttribute('hash', hash);
         el.setAttribute('type', mime)
         el.addEventListener('contextmenu', function(event){
-            console.log('context:' + hash + ':' + el.width + ':' + el.height);
+            window.qpage.set_active_image_info(hash, el.width, el.height);
         }, false);
         insertEl(el);
     }
@@ -67,9 +67,9 @@
         link.appendChild(content);
         link.setAttribute('href', url);
         insertEl(link);
-        link.addEventListener('contextmenu', function() {
-                console.log('href:' + url);
-                currentLink = link;
+        link.addEventListener('contextmenu', function(ev) {
+            window.qpage.set_active_link(ev.target.getAttribute('href'));
+            currentLink = link;
         }, false);
     }
     function changeLink(url) {
@@ -89,7 +89,7 @@
     }
     var content = document.getElementById('content');
     content.addEventListener('focus', function() {
-        console.log("body");
+        window.qpage.set_current_focus("body");
         isContent = true;
     }, false);
     content.addEventListener('keydown', function(event) {
@@ -98,30 +98,30 @@
             var el = document.createElement("img");
             el.className = "tab";
             insertEl(el);
-            console.log("change");
+            window.qpage.page_changed();
             return false;
         }
     }, false);
     var title = document.getElementById('title');
     title.addEventListener('focus', function() {
-        console.log("head");
+        window.qpage.set_current_focus("head");
         isContent = false;
     }, false);
     var checkboxes = document.querySelectorAll('input[type=checkbox]');
     [].forEach.call(checkboxes, function(el){
         el.addEventListener('change', function() {
-        console.log("change");
+        window.qpage.page_changed();
         this.setAttribute("checked", this.checked);
     }, false);});
     var resources = document.querySelectorAll('img[hash]');
     [].forEach.call(resources, function(el){
         el.addEventListener('contextmenu', function() {
-            console.log('context:' + el.getAttribute('hash') + ':' + el.width + ':' + el.height);
+            window.qpage.set_active_image_info(el.getAttribute('hash'), el.width, el.height);
     }, false);});
     var links = document.querySelectorAll('a');
     [].forEach.call(links, function(el){
         el.addEventListener('contextmenu', function() {
-            console.log('href:' + el.getAttribute('href'));
+            window.qpage.set_active_link(el.getAttribute('href'));
             currentLink = el;
     }, false);});
 </script>

--- a/everpad/pad/editor.py
+++ b/everpad/pad/editor.py
@@ -74,16 +74,30 @@ class Page(QWebPage):
         self.active_image = None
         self.active_link = None
 
+        # This allows JavaScript to call back to Slots, connect to Signals
+        # and access/modify Qt props
+        self.mainFrame().addToJavaScriptWindowObject("qpage", self)
+
+    @Slot(str)
+    def set_current_focus(self, focused):
+        self.current = focused
+
+    @Slot()
+    def page_changed(self):
+        self.edit.page_changed()
+
+    @Slot(str, int, int)
+    def set_active_image_info(self, image, width, height):
+        self.active_image = image
+        self.active_width = width
+        self.active_height = height
+
+    @Slot(str)
+    def set_active_link(self, url):
+        self.active_link = url
+
     def javaScriptConsoleMessage(self, message, lineNumber, sourceID):
         print message
-        if message in ('head', 'body'):
-            self.current = message
-        if message == 'change':
-            self.edit.page_changed()  # shit!
-        if message.find('context:') == 0:
-            self.active_image, self.active_width, self.active_height = message.split(':')[1:]
-        if message.find('href:') == 0:
-            self.active_link = message[5:]
 
 
 class ContentEdit(QObject):


### PR DESCRIPTION
QtFrame.addToJavaScriptWindowObject allows your Qt Application to
register QObjects as attributes on the Javascript Window object.

Use this, in conjunction with strongly typed Slots() in the QWebPage
subclass, to remove the previously used console.log() message-passing
tricks.

Also, I tweaked the logic in insertLink() to fix a bug where doing
"Change Link" twice would continue to show the first link.
