### PR TITLE
Automatically open the findbar in edit view from search

### DIFF
--- a/everpad/lens.py
+++ b/everpad/lens.py
@@ -11,6 +11,7 @@ import dbus.mainloop.glib
 import sys
 import os
 import gettext
+import json
 
 
 path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'i18n')
@@ -80,13 +81,14 @@ class EverpadLens(SingleScopeLens):
             1000, Note.ORDER_TITLE,
         ):
             note = Note.from_tuple(note_struct)
-            results.append(str(note.id),
+            results.append(json.dumps({'id': note.id, 'search': search}),
                 'everpad-note', self.category, "text/html",
                 note.title, html2text(note.content),
             '')
 
-    def preview(self, scope, id):
-        note = Note.from_tuple(provider.get_note(int(id)))
+    def preview(self, scope, uri):
+        obj = json.loads(uri)
+        note = Note.from_tuple(provider.get_note(obj['id']))
         preview = Unity.GenericPreview.new(
             note.title, html2text(note.content), None,
         )
@@ -102,8 +104,9 @@ class EverpadLens(SingleScopeLens):
         preview.add_action(edit)
         return preview
 
-    def handle_uri(self, scope, id):
-        get_pad().open(int(id))
+    def handle_uri(self, scope, uri):
+        obj = json.loads(uri)
+        get_pad().open_with_search_term(int(obj['id']), obj.get('search', ''))
         return self.hide_dash_response()
 
     def on_filtering_changed(self, scope):

--- a/everpad/pad/editor.py
+++ b/everpad/pad/editor.py
@@ -113,6 +113,9 @@ class FindBar(QWidget):
         self.ui.btnHighlight.clicked.connect(self.update_highlight)
         self.ui.chkMatchCase.clicked.connect(self.match_case_updated)
 
+    def set_search_term(self, search_term):
+        self.ui.edtFindText.setText(search_term)
+
     def get_flags(self, default_flags=None):
         flags = QWebPage.FindFlag.FindWrapsAroundDocument
         if default_flags is not None:

--- a/everpad/pad/indicator.py
+++ b/everpad/pad/indicator.py
@@ -67,7 +67,7 @@ class Indicator(QSystemTrayIcon):
         self.menu.addSeparator()
         self.menu.addAction(self.tr('Exit'), self.exit)
 
-    def open(self, note):
+    def open(self, note, search_term=''):
         old_note_window = self.opened_notes.get(note.id, None)
         if old_note_window and not getattr(old_note_window, 'closed', True):
             editor = self.opened_notes[note.id]
@@ -76,6 +76,9 @@ class Indicator(QSystemTrayIcon):
             editor = Editor(self.app, note)
             editor.show()
             self.opened_notes[note.id] = editor
+        if search_term:
+            editor.findbar.set_search_term(search_term)
+            editor.findbar.show()
         return editor
 
     @Slot()
@@ -155,8 +158,12 @@ class EverpadService(dbus.service.Object):
 
     @dbus.service.method("com.everpad.App", in_signature='i', out_signature='')
     def open(self, id):
+        self.open_with_search_term(id, '')
+
+    @dbus.service.method("com.everpad.App", in_signature='is', out_signature='')
+    def open_with_search_term(self, id, search_term):
         note = Note.from_tuple(self.app.provider.get_note(id))
-        self.app.indicator.open(note)
+        self.app.indicator.open(note, search_term)
 
     @dbus.service.method("com.everpad.App", in_signature='', out_signature='')
     def create(self):


### PR DESCRIPTION
If the note was openend from lens via some search term, open the note
editor with the find bar pre-opened with the search term already filled
in and the first occurrence highlighted.

It encodes this data into the lens' "uri"s by json encoding a metadata
dictionary (instead of assuming the uri == an integer)

This change concludes work on #90
