### PR TITLE
Support http proxies during authorization

### DIFF
--- a/everpad/pad/indicator.py
+++ b/everpad/pad/indicator.py
@@ -2,6 +2,7 @@ import sys
 sys.path.insert(0, '../..')
 from PySide.QtCore import Slot, QTranslator, QLocale, Signal, QSettings, QT_TRANSLATE_NOOP
 from PySide.QtGui import QApplication, QSystemTrayIcon, QMenu, QIcon, QCursor
+from PySide.QtNetwork import QNetworkProxyFactory
 from everpad.basetypes import Note, Notebook, Tag, NONE_ID, NONE_VAL
 from everpad.tools import get_provider, get_pad, get_auth_token, print_version
 from everpad.pad.editor import Editor
@@ -188,6 +189,7 @@ class PadApp(QApplication):
         # direction. See for example i18n/ar_EG.ts
         QT_TRANSLATE_NOOP('QApplication', 'QT_LAYOUT_DIRECTION')
         self.installTranslator(self.translator)
+        QNetworkProxyFactory.setUseSystemConfiguration(True)
         self.indicator = Indicator(self)
         self.update_icon()
         self.indicator.show()

--- a/everpad/provider/tools.py
+++ b/everpad/provider/tools.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from everpad.provider.models import Base
 from everpad.const import HOST, SCHEMA_VERSION
+from everpad.tools import get_proxy_config, get_auth_token
 from urlparse import urlparse
 import os
 
@@ -38,14 +39,6 @@ def get_db_session(db_path=None):
     conn = session.connection()
     conn.connection.create_function('lower', 1, _nocase_lower)
     return session
-
-
-def get_proxy_config(scheme):
-    for fmt in ('%s_proxy', '%s_PROXY'):
-        proxy = os.environ.get(fmt % scheme)
-        if proxy is not None:
-            return proxy
-    return None
 
 
 def get_note_store(auth_token=None):

--- a/everpad/tools.py
+++ b/everpad/tools.py
@@ -5,6 +5,7 @@ from everpad.const import API_VERSION, SCHEMA_VERSION, VERSION
 import dbus
 import re
 import sys
+import os
 
 
 class InterfaceWrapper(object):
@@ -126,3 +127,10 @@ def print_version():
     print 'API version: %d' % API_VERSION
     print 'Schema version: %d' % SCHEMA_VERSION
     sys.exit(0)
+
+def get_proxy_config(scheme):
+    for fmt in ('%s_proxy', '%s_PROXY'):
+        proxy = os.environ.get(fmt % scheme)
+        if proxy is not None:
+            return proxy
+    return None


### PR DESCRIPTION
Enabled SystemConfiguration in QNetworkProxyFactory in management.py as
well as initializing oauth2.Client's proxy settings.

Moved the proxy helper from everpad.provider.tools to everpad.tools,
since the oath stuff is in the indicator, not in the pad, and getting the
proxy info from the environment should happen in both.

Fixes #156

Test Plan: Configured my system to read through a localhost HTTP CONNECT
proxy (https://github.com/fmoo/twisted-connect-proxy), verified that the
authorize flow was sending both the initial OAuth handshake, as well as
the HTTP requests from the QWebView, etc,  through the proxy.
