### PR TITLE
Revert progressbar fix applied in 948945e8

### DIFF
--- a/everpad/pad/indicator.py
+++ b/everpad/pad/indicator.py
@@ -204,7 +204,7 @@ class PadApp(QApplication):
             QSystemTrayIcon.Information)
 
     def on_sync_state_changed(self, state):
-        if bool(self.settings.value('launcher-progress', 1)):
+        if int(self.settings.value('launcher-progress', 1)):
             self.launcher.update({
                 'progress': float(state + 1) / len(SYNC_STATES),
                 'progress-visible': state not in (SYNC_STATE_START, SYNC_STATE_FINISH),


### PR DESCRIPTION
The change from `int` to `bool` applied in 948945e8 broke the disable launcher progressbar option as the bool of `'0'` is always True. 
