### PR TITLE
Tag removal, Launcher usefulness, Tag/Notebook selection

### DIFF
--- a/everpad/pad/indicator.py
+++ b/everpad/pad/indicator.py
@@ -314,8 +314,9 @@ def main():
             pad.settings()
         if args.attach:
             pad.create_wit_attach(args.attach)
-        if args.all_notes:
+        if args.all_notes or len(sys.argv) <= 1:
             pad.all_notes()
+        
         sys.exit(0)
 
 if __name__ == '__main__':

--- a/everpad/pad/list.py
+++ b/everpad/pad/list.py
@@ -64,11 +64,13 @@ class List(QMainWindow):
     @Slot(QItemSelection, QItemSelection)
     def selection_changed(self, selected, deselected):
         if len(selected.indexes()):
+            self.ui.tagsList.clearSelection()
             self.notebook_selected(selected.indexes()[-1])
     
     @Slot(QItemSelection, QItemSelection)
     def tag_selection_changed(self, selected, deselected):
         if len(selected.indexes()):
+            self.ui.notebooksList.clearSelection()
             self.tag_selected(selected.indexes()[-1])
 
     def showEvent(self, *args, **kwargs):
@@ -218,8 +220,6 @@ class List(QMainWindow):
             self.app.provider.delete_tag(item.tag.id)
             self.app.send_notify(self.tr('Tag "%s" deleted!') % item.tag.name)
             self._reload_tags_list()
-
-
 
     @Slot()
     def new_note(self):


### PR DESCRIPTION
Delete tags in MainWindow, #121

Opening Everpad again opens All Notes, #224

Clearing selection of tags when a notebook is selected and the other way around (no issue to refer to)
