### PR TITLE
Fixed a bug occuring in Mint KDE 14 when starting provider daemon

### DIFF
--- a/everpad/specific/__init__.py
+++ b/everpad/specific/__init__.py
@@ -24,7 +24,7 @@ def get_tray_icon(is_black=False):
         return QIcon.fromTheme('everpad-mono', QIcon('../../data/everpad-mono.png'))
 
 
-if 'kde' in os.environ.get('DESKTOP_SESSION', ''):  # kde init qwidget for wallet access
+if 'kde' in os.environ.get('DESKTOP_SESSION', '') or os.environ.get('KDE_FULL_SESSION') == 'true':  # kde init qwidget for wallet access
     from PySide.QtGui import QApplication
     AppClass = QApplication
 else:


### PR DESCRIPTION
When starting everpad/provider/daemon.py, following error occures:

<pre>QWidget: Cannot create a QWidget when no GUI is being used</pre>


This is caused by incorrect recognition of KDE session. This commit should fix it.
