### PR TITLE
add a sync table to avoid unnecessary sync with evernote servers

### DIFF
--- a/everpad/provider/models.py
+++ b/everpad/provider/models.py
@@ -275,3 +275,10 @@ class Place(Base):
     __tablename__ = 'places'
     id = Column(Integer, primary_key=True)
     name = Column(String)
+
+
+class Sync(Base):
+    __tablename__ = 'sync'
+    id = Column(Integer, primary_key=True)
+    update_count = Column(Integer)
+    last_sync = Column(Integer)


### PR DESCRIPTION
This branch adds a Sync table to keep the state of syncs. This way we avoid unnecessary sync, specially during everpad start up. I realize there are no tests and would like your help to properly add tests to this branch.
