### PR TITLE
fix warnings from test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 syntax: glob
 
+*.swp
 *.pyc
 *pip-delete-this-directory.txt
 /build

--- a/everpad/provider/sync/note.py
+++ b/everpad/provider/sync/note.py
@@ -172,7 +172,8 @@ class PullNote(BaseSync, ShareNoteMixin):
             self._check_sharing_information(note, note_ttype)
 
             resource_ids = self._receive_resources(note, note_ttype)
-            self._remove_resources(note, resource_ids)
+            if resource_ids:
+                self._remove_resources(note, resource_ids)
 
         self.session.commit()
         self._remove_notes()
@@ -240,13 +241,18 @@ class PullNote(BaseSync, ShareNoteMixin):
 
     def _remove_notes(self):
         """Remove not exists notes"""
-        self.session.query(models.Note).filter((
-            ~models.Note.id.in_(self._exists)
-            | ~models.Note.conflict_parent_id.in_(self._exists)
-        ) & ~models.Note.action.in_((
-            const.ACTION_NOEXSIST, const.ACTION_CREATE,
-            const.ACTION_CHANGE, const.ACTION_CONFLICT,
-        ))).delete(synchronize_session='fetch')
+        if self._exists:
+            q = ((~models.Note.id.in_(self._exists) |
+                ~models.Note.conflict_parent_id.in_(self._exists)) &
+                ~models.Note.action.in_((
+                    const.ACTION_NOEXSIST, const.ACTION_CREATE,
+                    const.ACTION_CHANGE, const.ACTION_CONFLICT)))
+        else:
+            q = (~models.Note.action.in_((
+                    const.ACTION_NOEXSIST, const.ACTION_CREATE,
+                    const.ACTION_CHANGE, const.ACTION_CONFLICT)))
+        self.session.query(models.Note).filter(q).delete(
+            synchronize_session='fetch')
         self.session.commit()
 
     def _receive_resources(self, note, note_ttype):

--- a/everpad/provider/sync/notebook.py
+++ b/everpad/provider/sync/notebook.py
@@ -142,8 +142,13 @@ class PullNotebook(BaseSync):
 
     def _remove_notebooks(self):
         """Remove not received notebooks"""
+        if self._exists:
+            q = (~models.Notebook.id.in_(self._exists)
+                & (models.Notebook.action != const.ACTION_CREATE)
+                & (models.Notebook.action != const.ACTION_CHANGE))
+        else:
+            q = ((models.Notebook.action != const.ACTION_CREATE)
+                & (models.Notebook.action != const.ACTION_CHANGE))
+
         self.session.query(models.Notebook).filter(
-            ~models.Notebook.id.in_(self._exists)
-            & (models.Notebook.action != const.ACTION_CREATE)
-            & (models.Notebook.action != const.ACTION_CHANGE)
-        ).delete(synchronize_session='fetch')
+            q).delete(synchronize_session='fetch')

--- a/everpad/provider/sync/tag.py
+++ b/everpad/provider/sync/tag.py
@@ -90,7 +90,7 @@ class PullTag(BaseSync):
         self._remove_tags()
 
     def _create_tag(self, tag_ttype):
-        """Create notebook from server"""
+        """Create tag from server"""
         tag = models.Tag(guid=tag_ttype.guid)
         tag.from_api(tag_ttype)
         self.session.add(tag)
@@ -108,7 +108,10 @@ class PullTag(BaseSync):
 
     def _remove_tags(self):
         """Remove not exist tags"""
-        self.session.query(models.Tag).filter(
-            ~models.Tag.id.in_(self._exists)
-            & (models.Tag.action != const.ACTION_CREATE)
-        ).delete(synchronize_session='fetch')
+        if self._exists:
+            q = (~models.Tag.id.in_(self._exists)
+                & (models.Tag.action != const.ACTION_CREATE))
+        else:
+            q = (models.Tag.action != const.ACTION_CREATE)
+        self.session.query(models.Tag).filter(q).delete(
+            synchronize_session='fetch')


### PR DESCRIPTION
This branch fixes some test runner warnings such as:

Test delete non exists note after pull ... /usr/lib/python2.7/dist-packages/sqlalchemy/sql/expression.py:1927: SAWarning: The IN-predicate on "notes.id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return self._in_impl(operators.in_op, operators.notin_op, other)
/usr/lib/python2.7/dist-packages/sqlalchemy/sql/expression.py:1927: SAWarning: The IN-predicate on "notes.conflict_parent_id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return self._in_impl(operators.in_op, operators.notin_op, other)
ok
Test delete notebooks after pull ... /usr/lib/python2.7/dist-packages/sqlalchemy/sql/expression.py:1927: SAWarning: The IN-predicate on "notebooks.id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return self._in_impl(operators.in_op, operators.notin_op, other)
ok
Test delete non exists after pull ... /usr/lib/python2.7/dist-packages/sqlalchemy/sql/expression.py:1927: SAWarning: The IN-predicate on "tags.id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return self._in_impl(operators.in_op, operators.notin_op, other)
ok
