### PR TITLE
Fix occasional everpad-provider segfaults

### DIFF
--- a/everpad/provider/daemon.py
+++ b/everpad/provider/daemon.py
@@ -111,6 +111,7 @@ def main():
     try:
         fcntl.lockf(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        dbus.mainloop.glib.threads_init()
         app = ProviderApp(args.verbose, sys.argv)
         app.exec_()
     except IOError:


### PR DESCRIPTION
Sometimes everpad-provider crash with segfault on start. There's always dbus.so library functions calls in the crash trace.
