### PR TITLE
'app' may not have been initialized if an exception occurs

### DIFF
--- a/everpad/provider/daemon.py
+++ b/everpad/provider/daemon.py
@@ -116,7 +116,7 @@ def main():
     except IOError:
         print("everpad-provider already ran")
     except Exception as e:
-        app.logger.debug(e)
+        logging.exception("failed to start everpad-provider")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
using logging.exception()
