### PR TITLE
Fix PEP8 coding style violations (all but E501)

### DIFF
--- a/tests/test_basetypes.py
+++ b/tests/test_basetypes.py
@@ -34,6 +34,7 @@ class TestBaseTypes(unittest.TestCase):
     def test_give(self):
         class Fake(object):
             id = 0
+
             @property
             def id_dbus(self):
                 return self.id

--- a/thrift/TSCons.py
+++ b/thrift/TSCons.py
@@ -20,14 +20,16 @@
 from os import path
 from SCons.Builder import Builder
 
+
 def scons_env(env, add=''):
-  opath = path.dirname(path.abspath('$TARGET'))
-  lstr = 'thrift --gen cpp -o ' + opath + ' ' + add + ' $SOURCE'
-  cppbuild = Builder(action = lstr)
-  env.Append(BUILDERS = {'ThriftCpp' : cppbuild})
+    opath = path.dirname(path.abspath('$TARGET'))
+    lstr = 'thrift --gen cpp -o ' + opath + ' ' + add + ' $SOURCE'
+    cppbuild = Builder(action=lstr)
+    env.Append(BUILDERS={'ThriftCpp': cppbuild})
+
 
 def gen_cpp(env, dir, file):
-  scons_env(env)
-  suffixes = ['_types.h', '_types.cpp']
-  targets = map(lambda s: 'gen-cpp/' + file + s, suffixes)
-  return env.ThriftCpp(targets, dir+file+'.thrift')
+    scons_env(env)
+    suffixes = ['_types.h', '_types.cpp']
+    targets = map(lambda s: 'gen-cpp/' + file + s, suffixes)
+    return env.ThriftCpp(targets, dir + file + '.thrift')

--- a/thrift/TSerialization.py
+++ b/thrift/TSerialization.py
@@ -20,15 +20,16 @@
 from protocol import TBinaryProtocol
 from transport import TTransport
 
-def serialize(thrift_object, protocol_factory = TBinaryProtocol.TBinaryProtocolFactory()):
+
+def serialize(thrift_object, protocol_factory=TBinaryProtocol.TBinaryProtocolFactory()):
     transport = TTransport.TMemoryBuffer()
     protocol = protocol_factory.getProtocol(transport)
     thrift_object.write(protocol)
     return transport.getvalue()
 
-def deserialize(base, buf, protocol_factory = TBinaryProtocol.TBinaryProtocolFactory()):
+
+def deserialize(base, buf, protocol_factory=TBinaryProtocol.TBinaryProtocolFactory()):
     transport = TTransport.TMemoryBuffer(buf)
     protocol = protocol_factory.getProtocol(transport)
     base.read(protocol)
     return base
-


### PR DESCRIPTION
I ran `pep8 --ignore=E501 *.py` and fixed some errors.

TODO: Fix E501 errors.

As part of http://24pullrequests.com/
