### PR TITLE
Fixing #428 by forcing the nestable tags

### DIFF
--- a/everpad/provider/sync/note.py
+++ b/everpad/provider/sync/note.py
@@ -113,6 +113,10 @@ class PushNote(BaseSync, ShareNoteMixin):
             html=content[:limits.EDAM_NOTE_CONTENT_LEN_MAX]
         ))).strip().encode('utf8')
 
+        BeautifulSoup.NESTABLE_TAGS['li'] = ['ul', 'ol']
+        BeautifulSoup.NESTABLE_TAGS['ul'] = ['li']
+        BeautifulSoup.NESTABLE_TAGS['ol'] = ['li']
+
         soup = BeautifulSoup(enml_content, selfClosingTags=[
             'img', 'en-todo', 'en-media', 'br', 'hr',
         ])


### PR DESCRIPTION
By default the nestable tags aren't correctly configured in BeautifulSoup.  Adding them manually makes nested lists possible.
This should fix issue #428.
