### PR TITLE
add traceback for exception in sync log

### DIFF
--- a/everpad/provider/daemon.py
+++ b/everpad/provider/daemon.py
@@ -14,6 +14,7 @@ import getpass
 import argparse
 import sys
 import logging
+import traceback
 
 
 class ProviderApp(AppClass):
@@ -82,6 +83,12 @@ class ProviderApp(AppClass):
         self.logger.debug(data)
         if self.verbose:
             print data
+
+    def log_exception(self, e):
+        self.logger.exception(e)
+        if self.verbose:
+            traceback.print_exc()
+
 
     @Slot()
     def terminate(self):

--- a/everpad/provider/sync/agent.py
+++ b/everpad/provider/sync/agent.py
@@ -132,7 +132,7 @@ class SyncThread(QtCore.QThread):
         except Exception, e:  # maybe log this
             self.session.rollback()
             self._init_db()
-            self.app.log(e)
+            self.app.log_exception(e)
         finally:
             self.sync_state_changed.emit(const.SYNC_STATE_FINISH)
             self.status = const.STATUS_NONE

--- a/everpad/provider/sync/note.py
+++ b/everpad/provider/sync/note.py
@@ -213,6 +213,8 @@ class PullNote(BaseSync, ShareNoteMixin):
 
     def _create_note(self, note_ttype):
         """Create new note"""
+
+        self.app.log("creating %s" % (note_ttype.title))
         note_ttype = self._get_full_note(note_ttype)
 
         note = models.Note(guid=note_ttype.guid)
@@ -238,6 +240,7 @@ class PullNote(BaseSync, ShareNoteMixin):
 
     def _create_conflict(self, note, note_ttype):
         """Create conflict note"""
+        self.app.log("create conflict %s" % (note_ttype.title))
         conflict_note = models.Note()
         conflict_note.from_api(note_ttype, self.session)
         conflict_note.guid = ''


### PR DESCRIPTION
add some traceback in provider log  (.everpad/logs/everpad-provider.log) to help bug fix

```
2015-07-23 23:31:08,608 - everpad-provider - DEBUG - Pulling note "美元指数" from remote server.
2015-07-23 23:31:11,280 - everpad-provider - ERROR - expected a character buffer object
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/agent.py", line 130, in perform
    self.remote_changes()
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/agent.py", line 170, in remote_changes
    note.PullNote(*self._get_sync_args()).pull()
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/note.py", line 181, in pull
    resource_ids = self._receive_resources(note, note_ttype)
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/note.py", line 287, in _receive_resources
    resource.from_api(resource_ttype)
  File "build/bdist.linux-x86_64/egg/everpad/provider/models.py", line 271, in from_api
    data.write(resource.data.body)
TypeError: expected a character buffer object
2015-07-23 23:31:11,281 - everpad-provider - DEBUG - Sync performed.
```
