### PR TITLE
fix picture resource sync exception

### DIFF
--- a/everpad/provider/sync/note.py
+++ b/everpad/provider/sync/note.py
@@ -267,6 +267,9 @@ class PullNote(BaseSync, ShareNoteMixin):
         resources_ids = []
 
         for resource_ttype in note_ttype.resources or []:
+            if resource_ttype.data.size and not resource_ttype.data.body:
+                resource_ttype = self.note_store.getResource(self.auth_token, 
+                        guid=resource_ttype.guid, withData=True, withRecognition=True, withAttributes=True)
             try:
                 resource = self.session.query(models.Resource).filter(
                     models.Resource.guid == resource_ttype.guid,
@@ -285,7 +288,6 @@ class PullNote(BaseSync, ShareNoteMixin):
                 self.session.add(resource)
                 self.session.commit()
                 resources_ids.append(resource.id)
-
         return resources_ids
 
     def _remove_resources(self, note, resources_ids):

--- a/everpad/provider/sync/note.py
+++ b/everpad/provider/sync/note.py
@@ -269,7 +269,7 @@ class PullNote(BaseSync, ShareNoteMixin):
         for resource_ttype in note_ttype.resources or []:
             if resource_ttype.data.size and not resource_ttype.data.body:
                 resource_ttype = self.note_store.getResource(self.auth_token, 
-                        guid=resource_ttype.guid, withData=True, withRecognition=True, withAttributes=True)
+                        guid=resource_ttype.guid, withData=True, withRecognition=True, withAttributes=True, withAlternateData=False)
             try:
                 resource = self.session.query(models.Resource).filter(
                     models.Resource.guid == resource_ttype.guid,


### PR DESCRIPTION
when syncing note with large picture,  resource_ttype.data.body will be None,  need to get download full resource with getResource()

traceback:

```
2015-07-23 23:31:08,608 - everpad-provider - DEBUG - Pulling note "美元指数" from remote server.
2015-07-23 23:31:11,280 - everpad-provider - ERROR - expected a character buffer object
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/agent.py", line 130, in perform
    self.remote_changes()
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/agent.py", line 170, in remote_changes
    note.PullNote(*self._get_sync_args()).pull()
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/note.py", line 181, in pull
    resource_ids = self._receive_resources(note, note_ttype)
  File "build/bdist.linux-x86_64/egg/everpad/provider/sync/note.py", line 287, in _receive_resources
    resource.from_api(resource_ttype)
  File "build/bdist.linux-x86_64/egg/everpad/provider/models.py", line 271, in from_api
    data.write(resource.data.body)
TypeError: expected a character buffer object
2015-07-23 23:31:11,281 - everpad-provider - DEBUG - Sync performed.
```
